### PR TITLE
moved to secure connection

### DIFF
--- a/classes/class.wikiextract.php
+++ b/classes/class.wikiextract.php
@@ -54,7 +54,7 @@ class WikiExtract {
 	// Paramaters passed to the Wik API, including search word.	
 		$params = '?action=parse&prop=wikitext&page='.$word.'&format=xml';
 		
-		$ch = curl_init('http://'.$this->langCode.'.wiktionary.org/w/api.php'.$params);
+		$ch = curl_init('https://'.$this->langCode.'.wiktionary.org/w/api.php'.$params);
 		curl_setopt($ch, CURLOPT_USERAGENT, $userAgent);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($ch,CURLOPT_ENCODING , "gzip");


### PR DESCRIPTION
Wikipedia goes all-HTTPS, starting immediately. So requesting http connection with curl gives empty response.
