### PR TITLE
Initial Consistency Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+/composer.lock

--- a/WikParser.php
+++ b/WikParser.php
@@ -175,7 +175,7 @@ class WikParser{
             case "def":
                 if(isset($this->langParameters) and isset($this->word) and isset($this->source) and isset($this->count)){
                     $DefParse = new DefParse($this->langParameters);
-                    $wikitext = $this->get_wiki_text($this->langParameters, $this->source, $this->word);
+                    $wikitext = $this->getWikiText($this->langParameters, $this->source, $this->word);
                     if(isset($DefParse)){
                         $parsedDefinition = $DefParse->getDef($wikitext, $this->count);
                     }
@@ -187,9 +187,9 @@ class WikParser{
             case "pos":
                 if(isset($this->langParameters) and isset($this->word) and isset($this->source) and isset($this->count)){
                     $posparse = new PosParse($this->langParameters);
-                    $wikitext = $this->get_wiki_text($this->langParameters, $this->source, $this->word);
+                    $wikitext = $this->getWikiText($this->langParameters, $this->source, $this->word);
                     if(isset($DefParse)){
-                        $parsedDefinition = $posparse->get_pos($wikitext, $this->count);
+                        $parsedDefinition = $posparse->getPos($wikitext, $this->count);
                     }
                 }
                 break;
@@ -199,9 +199,9 @@ class WikParser{
             case "syn":
                 if(isset($this->langParameters) and isset($this->word) and isset($this->source) and isset($this->count)){
                     $SynParse = new SynParse($this->langParameters);
-                    $wikitext = $this->get_wiki_text($this->langParameters, $this->source, $this->word);
+                    $wikitext = $this->getWikiText($this->langParameters, $this->source, $this->word);
                     if(isset($DefParse)){
-                        $parsedDefinition = $SynParse->get_syn($wikitext, $this->count);
+                        $parsedDefinition = $SynParse->getSyn($wikitext, $this->count);
                     }
                 }
                 break;
@@ -212,9 +212,9 @@ class WikParser{
             case "hyper":
                 if(isset($this->langParameters) and isset($this->word) and isset($this->source) and isset($this->count)){
                     $HyperParse = new HyperParse($this->langParameters);
-                    $wikitext = $this->get_wiki_text($this->langParameters, $this->source, $this->word);
+                    $wikitext = $this->getWikiText($this->langParameters, $this->source, $this->word);
                     if(isset($DefParse)){
-                        $parsedDefinition = $HyperParse->get_hyper($wikitext, $this->count);
+                        $parsedDefinition = $HyperParse->getHyper($wikitext, $this->count);
                     }
                 }
                 break;
@@ -224,9 +224,9 @@ class WikParser{
             case "gender":
                 if(isset($this->langParameters) and isset($this->word) and isset($this->source) and isset($this->count)){
                     $GenderParse = new GenderParse($this->langParameters);
-                    $wikitext = $this->get_wiki_text($this->langParameters, $this->source, $this->word);
+                    $wikitext = $this->getWikiText($this->langParameters, $this->source, $this->word);
                     if(isset($DefParse)){
-                        $parsedDefinition = $GenderParse->get_gender($wikitext, $this->count);
+                        $parsedDefinition = $GenderParse->getGender($wikitext, $this->count);
                     }
                 }
                 break;
@@ -246,9 +246,9 @@ class WikParser{
 // Include wikiextract class and create new object with 2 variables. Returns the
 // contents of the wiktionary entry for a given word.
     /***********************************************************************************/
-    public function get_wiki_text($langParameters, $wikiSource, $word) {
+    public function getWikiText($langParameters, $wikiSource, $word) {
         $WikiExtract = new WikiExtract($langParameters, $wikiSource);
-        return $WikiExtract->get_wikitext($word);
+        return $WikiExtract->getWikiText($word);
     }
 
     /***********************************************************************************/

--- a/WikParser.php
+++ b/WikParser.php
@@ -1,7 +1,11 @@
 <?php
-namespace quuuit\Wikparser;
-use quuuit\Wikparser\lib\DefParse;
-use quuuit\Wikparser\lib\WikiExtract;
+namespace ybourque\Wikparser;
+use ybourque\Wikparser\lib\DefParse;
+use ybourque\Wikparser\lib\GenderParse;
+use ybourque\Wikparser\lib\HyperParse;
+use ybourque\Wikparser\lib\PosParse;
+use ybourque\Wikparser\lib\SynParse;
+use ybourque\Wikparser\lib\WikiExtract;
 
 class WikParser{
     public $parsedDefinition='';
@@ -151,7 +155,7 @@ class WikParser{
                 );
                 break;
         }
-        $this->langParameters['langHeader'] = $this->getLangHeader();
+        $this->langParameters['langHeader'] = $this->getLangHeader($langCode);
         return $this->parseQuery($query);
     }
     /***********************************************************************************/
@@ -160,7 +164,7 @@ class WikParser{
     /***********************************************************************************/
 // Number of results; default '100'
     /***********************************************************************************/
-// Set wikisource to local if not set. Values either 'local' or 'api'.	
+// Set wikisource to local if not set. Values either 'local' or 'api'.
     /***********************************************************************************/
     /***********************************************************************************/
     public function parseQuery($query){
@@ -169,7 +173,6 @@ class WikParser{
             // Include defparse class and create new object with 3 variables.
             /***********************************************************************************/
             case "def":
-
                 if(isset($this->langParameters) and isset($this->word) and isset($this->source) and isset($this->count)){
                     $DefParse = new DefParse($this->langParameters);
                     $wikitext = $this->get_wiki_text($this->langParameters, $this->source, $this->word);
@@ -182,7 +185,6 @@ class WikParser{
             // Include posparse class and create new object with 3 variables.
             /***********************************************************************************/
             case "pos":
-                include 'lib/class.posparse.php';
                 if(isset($this->langParameters) and isset($this->word) and isset($this->source) and isset($this->count)){
                     $posparse = new PosParse($this->langParameters);
                     $wikitext = $this->get_wiki_text($this->langParameters, $this->source, $this->word);
@@ -195,7 +197,6 @@ class WikParser{
             // Include synparse class and create new object with 3 variables.
             /***********************************************************************************/
             case "syn":
-                include 'lib/class.synparse.php';
                 if(isset($this->langParameters) and isset($this->word) and isset($this->source) and isset($this->count)){
                     $SynParse = new SynParse($this->langParameters);
                     $wikitext = $this->get_wiki_text($this->langParameters, $this->source, $this->word);
@@ -209,7 +210,6 @@ class WikParser{
             // Include hyperparse class and create new object with 3 variables. (Hypernyms)
             /***********************************************************************************/
             case "hyper":
-                include 'lib/class.hyperparse.php';
                 if(isset($this->langParameters) and isset($this->word) and isset($this->source) and isset($this->count)){
                     $HyperParse = new HyperParse($this->langParameters);
                     $wikitext = $this->get_wiki_text($this->langParameters, $this->source, $this->word);
@@ -222,7 +222,6 @@ class WikParser{
             // Include genderparse class and create new object with 3 variables. (Gender)
             /***********************************************************************************/
             case "gender":
-                include 'lib/class.genderparse.php';
                 if(isset($this->langParameters) and isset($this->word) and isset($this->source) and isset($this->count)){
                     $GenderParse = new GenderParse($this->langParameters);
                     $wikitext = $this->get_wiki_text($this->langParameters, $this->source, $this->word);
@@ -264,4 +263,4 @@ class WikParser{
         echo rtrim($printresults, $resultseparator);
     }
 }
-?>	
+?>

--- a/WikParser.php
+++ b/WikParser.php
@@ -51,113 +51,16 @@ class WikParser{
         $this->word = $word;
         $this->count = $count;
         $this->source = $source;
-        switch ($langCode) {
-            // English parameters
-            case "en":
-                $this->langParameters = array(
-                    "langCode" => "en",
-                    "langSeparator" => "----",
-                    "defHeader" => "",
-                    "defTag" => "# ",
-                    "synHeader" => "====Synonyms====",
-                    "hyperHeader" => "====Hypernyms====",
-                    "genderPattern" => "",
-                    "posMatchType" => "array",
-                    "posPattern" => "",
-                    "posArray" => array(
-                        '===Noun===', '===Verb===', '===Adjective===', '===Adverb===', '===Preposition===',
-                        '===Particle===', '===Pronouns===', '===Interjection===', '===Conjunction===',
-                        '===Article==='),
-                    "posExtraString" => "=",
-                );
-                break;
-            // French parameters
-            case "fr":
-                $this->langParameters = array(
-                    "langCode" => "fr",
-                    "langSeparator" => "== {{=",
-                    "defHeader" => "",
-                    "defTag" => "# ",
-                    "synHeader" => "==== {{S|synonymes}} ====",
-                    "hyperHeader" => "==== {{S|hyperonymes}} ====",
-                    "genderPattern" => "(\{\{([mf]|mf)\??\}\})",
-                    "posMatchType" => "preg",
-                    "posPattern" => "(\{\{\S\|[\d\w\s]+\|fr(\|num=[0-9])?\}\})u",
-                    "posArray" => array(),
-                    "posExtraString" => "{{S|",
-                );
-                break;
-            // Spanish parameters
-            case "es":
-                $this->langParameters = array(
-                    "langCode" => "es",
-                    "langSeparator" => "",
-                    "defHeader" => "",
-                    "defTag" => ";",
-                    "synHeader" => "'''Sinónimo",
-                    "hyperHeader" => "",
-                    "genderPattern" => "(\s?(masculino|femenino)(\|es)?\}\}\s?===)",
-                    "posMatchType" => "preg",
-                    "posPattern" => "(===\s?\{\{\w*[\|\s])u",
-                    "posArray" => array(),
-                    "posExtraString" => "",
-                );
-                break;
-            // German parameters
-            case "de":
-                $this->langParameters = array(
-                    "langCode" => "de",
-                    "langSeparator" => "({{Sprache|",
-                    "defHeader" => "{{Bedeutungen}}",
-                    "defTag" => ":",
-                    "synHeader" => "{{Synonyme}}",
-                    "hyperHeader" => "{{Oberbegriffe}}",
-                    "genderPattern" => "(\{\{[mfn]\}\}\s===)",
-                    "posMatchType" => "preg",
-                    "posPattern" => "(\{\{Wortart\|\w+\|)",
-                    "posArray" => array(),
-                    "posExtraString" => "{{Wortart|",
-                );
-                break;
-            // Fill in the following settings for a language of your choice.
-            case "":
-                $this->langParameters = array(
-                    "langCode" => "",		// string
-                    "langSeparator" => "",	// string
-                    "defHeader" => "",		// string
-                    "defTag" => "",			// string
-                    "synHeader" => "",		// string
-                    "hyperHeader" => "",	// string
-                    "genderPattern" => "",	// regex
-                    "posMatchType" => "",	// 'preg' or 'array'
-                    "posPattern" => "",		// regex
-                    "posArray" => "",		// array
-                    "posExtraString" => "",	// string
-                );
-                break;
-            // Default parameters (currently english)
-            default:
-                $this->langParameters = array(
-                    "langCode" => "en",
-                    "langSeparator" => "----",
-                    "defHeader" => "",
-                    "defTag" => "# ",
-                    "synHeader" => "====Synonyms====",
-                    "hyperHeader" => "====Hypernyms====",
-                    "genderPattern" => "",
-                    "posMatchType" => "array",
-                    "posPattern" => "",
-                    "posArray" => array(
-                        '===Noun===', '===Verb===', '===Adjective===', '===Adverb===', '===Preposition===',
-                        '===Particle===', '===Pronouns===', '===Interjection===', '===Conjunction===',
-                        '===Article==='),
-                    "posExtraString" => "=",
-                );
-                break;
-        }
-        $this->langParameters['langHeader'] = $this->getLangHeader($langCode);
+        $this->langParameters = $this->newLang($langCode);
         return $this->parseQuery($query);
     }
+
+    private function newLang($langCode)
+    {
+        $class = 'ybourque\Wikparser\lib\Lang\\' . ucfirst(strtolower($langCode));
+        return new $class();
+    }
+
     /***********************************************************************************/
     /***********************************************************************************/
 // Language code for search, default english (en)

--- a/lib/DefParse.php
+++ b/lib/DefParse.php
@@ -30,8 +30,8 @@ class DefParse {
 // public methods
 /***********************************************************************************/
 	public function getDef($wikitext, $count) {
-		$defArray = $this->extract_def($wikitext, $count);
-		return $this->strip_tags($defArray);
+		$defArray = $this->extractDef($wikitext, $count);
+		return $this->stripTags($defArray);
 	}
 /***********************************************************************************/
 // private methods
@@ -39,7 +39,7 @@ class DefParse {
 // Extracts all definitions by splitting at new lines and matching for definition
 // tags set in paramaters.
 /***********************************************************************************/
-	private function extract_def($wikitext, $count) {
+	private function extractDef($wikitext, $count) {
 		$defArray = array();
 
 		if (!empty($this->defHeader)) {
@@ -74,7 +74,7 @@ class DefParse {
 /***********************************************************************************/
 // Strips tags used for additional info and links to other words.
 /***********************************************************************************/
-	private function strip_tags($defArray) {
+	private function stripTags($defArray) {
 	// Strip anything enclosed between {{ }}
 		$strippedArray = preg_replace('(\{\{.*?\}\})', "", $defArray);
 	// Remove 1st half of [[word|Word]] strings.

--- a/lib/DefParse.php
+++ b/lib/DefParse.php
@@ -1,5 +1,5 @@
 <?php
-namespace quuuit\Wikparser\lib;
+namespace ybourque\Wikparser\lib;
 /***********************************************************************************/
 // This class is used to extract all definitions for a word.
 // See the language.config.php file for setting language specific parameters.
@@ -12,7 +12,7 @@ class DefParse {
 	private $langCode;		// language code (e.g. en, fr, da, etc.)
 	private $defHeader; 	// definitions header, set in config file
 	private $defTag;		// definitions tag, set in config file
-	
+
 /***********************************************************************************/
 // construct
 /***********************************************************************************/
@@ -44,12 +44,12 @@ class DefParse {
 
 		if (!empty($this->defHeader)) {
 			$sectionPattern = "(".preg_quote($this->defHeader).".*?\n\n)s";
-		// Find all matches for header + text until double newline.	
+		// Find all matches for header + text until double newline.
 			preg_match_all($sectionPattern, $wikitext, $sectionMatches);
 			if ($sectionMatches) {
 				$defPattern = "/\n".str_replace(" ", "\s", preg_quote($this->defTag)).".*/";
 				foreach ($sectionMatches[0] as $value) {
-				// Find all matches for deftag + text until newline.	
+				// Find all matches for deftag + text until newline.
 					preg_match_all($defPattern, $value, $defMatches);
 					if ($defMatches) {
 						foreach ($defMatches[0] as $value) {
@@ -63,7 +63,7 @@ class DefParse {
 				die("No definitions section found.");
 			}
 		}
-		else {		
+		else {
 			$defPattern = "/\n".str_replace(" ", "\s", preg_quote($this->defTag)).".*/";
 			preg_match_all($defPattern, $wikitext, $matches);
 			if ($matches) {
@@ -85,7 +85,7 @@ class DefParse {
 		$strippedArray = str_replace("]]", "", $strippedArray);
 	// Remove definition identifier
 		$strippedArray = str_replace($this->defTag, "", $strippedArray);
-		
+
 		return $strippedArray;
 	}
 /***********************************************************************************/

--- a/lib/GenderParse.php
+++ b/lib/GenderParse.php
@@ -1,4 +1,6 @@
 <?php
+namespace ybourque\Wikparser\lib;
+
 /***********************************************************************************/
 // This class is used to parse the wikitionary raw data in order to extract gender
 // for a given word.
@@ -11,7 +13,7 @@ class GenderParse {
 /***********************************************************************************/
 	private $langCode;			// language code (e.g. en, fr, da, etc.)
 	private $genderPattern;		// Gender regex pattern, set in config file
-	
+
 /***********************************************************************************/
 // construct
 /***********************************************************************************/
@@ -26,13 +28,13 @@ class GenderParse {
 	}
 /***********************************************************************************/
 // public methods; used to retrieve contents of variables
-/***********************************************************************************/	
+/***********************************************************************************/
 	public function get_gender($wikitext, $count) {
 		$genderArray = $this->extract_gender($wikitext, $count);
-		
+
 		include "./classes/class.strip.tags.php";
 		$stripTagsObject = new StripTags();
-		
+
 		return $stripTagsObject->strip_tags($genderArray, $this->langCode);
 	}
 /***********************************************************************************/
@@ -42,24 +44,24 @@ class GenderParse {
 /***********************************************************************************/
 	private function extract_gender($wikitext, $count) {
 		$tempGenderResults = array();
-		
+
 		if ($this->genderPattern != "") {
-			
+
 			preg_match_all($this->genderPattern, $wikitext, $matches);
-			
+
 			if (empty($matches[0]) !== true) {
 				foreach ($matches[0] as $value) {
 					$tempGenderResults[] = $value;
 				}
-			// Remove values based on the count provide by the user.	
+			// Remove values based on the count provide by the user.
 				$tempGenderResults = array_slice($tempGenderResults, 0, $count);
 			}
 		}
 		else {
 			die("No gender pattern specified for this language.");
 		}
-		
-	// Return results if array not empty.	
+
+	// Return results if array not empty.
 		if (empty($tempGenderResults) !==true) {
 			return array_unique($tempGenderResults);
 		}

--- a/lib/GenderParse.php
+++ b/lib/GenderParse.php
@@ -29,20 +29,20 @@ class GenderParse {
 /***********************************************************************************/
 // public methods; used to retrieve contents of variables
 /***********************************************************************************/
-	public function get_gender($wikitext, $count) {
-		$genderArray = $this->extract_gender($wikitext, $count);
+	public function getGender($wikitext, $count) {
+		$genderArray = $this->extractGender($wikitext, $count);
 
 		include "./classes/class.strip.tags.php";
 		$stripTagsObject = new StripTags();
 
-		return $stripTagsObject->strip_tags($genderArray, $this->langCode);
+		return $stripTagsObject->stripTags($genderArray, $this->langCode);
 	}
 /***********************************************************************************/
 // private methods
 /***********************************************************************************/
 // Extracts every occurrence of gender.
 /***********************************************************************************/
-	private function extract_gender($wikitext, $count) {
+	private function extractGender($wikitext, $count) {
 		$tempGenderResults = array();
 
 		if ($this->genderPattern != "") {

--- a/lib/GenderParse.php
+++ b/lib/GenderParse.php
@@ -31,10 +31,7 @@ class GenderParse {
 /***********************************************************************************/
 	public function getGender($wikitext, $count) {
 		$genderArray = $this->extractGender($wikitext, $count);
-
-		include "./classes/class.strip.tags.php";
 		$stripTagsObject = new StripTags();
-
 		return $stripTagsObject->stripTags($genderArray, $this->langCode);
 	}
 /***********************************************************************************/

--- a/lib/HyperParse.php
+++ b/lib/HyperParse.php
@@ -1,69 +1,71 @@
 <?php
+namespace ybourque\Wikparser\lib;
+
 /***********************************************************************************/
-// This class is used to parse the wikitionary raw data in order to extract synonyms
-// for a given word. Synonyms are not systematically included in Wiktionary entries.
+// This class is used to parse the wikitionary raw data in order to extract hypernyms
+// for a given word. Hypernyms are infrequent in Wiktionary entries.
 // See the language.config.php file for setting language specific parameters.
 /***********************************************************************************/
 
-class SynParse {
+class HyperParse {
 /***********************************************************************************/
 // Variables
 /***********************************************************************************/
-	private $langCode;		// language code (e.g. en, fr, da, etc.)
-	private $synHeader; 	// Synonyms header, set in config file
-	
+	private $langCode;			// language code (e.g. en, fr, da, etc.)
+	private $hyperHeader;		// Hypernyms header, set in config file
+
 /***********************************************************************************/
 // construct
 /***********************************************************************************/
 	public function __construct($langParameters) {
-		if (empty($langParameters['synHeader'])) {
-			die("ERROR: Synonym parameter is not set for this language in language.config.php.");
+		if (empty($langParameters['hyperHeader'])) {
+			die("ERROR: Hypernym parameter is not set for this language in language.config.php.");
 		}
 		else {
 			$this->langCode = $langParameters['langCode'];
-			$this->synHeader = $langParameters['synHeader'];
+			$this->hyperHeader = $langParameters['hyperHeader'];
 		}
 	}
 /***********************************************************************************/
 // public methods
 /***********************************************************************************/
-	public function get_syn($wikitext, $count) {
-		$synArray = $this->extract_syn($wikitext, $count);
-		return $this->strip_tags($synArray);
+	public function get_hyper($wikitext, $count) {
+		$hyperArray = $this->extract_hyper($wikitext, $count);
+		return $this->strip_tags($hyperArray);
 	}
 /***********************************************************************************/
 // private methods
 /***********************************************************************************/
-// Extracts synonyms from wikitext
+// Extracts hypernyms from wikitext
 /***********************************************************************************/
-	private function extract_syn($wikitext, $count) {
-		$synString = null;
-		$synPattern = "/$this->synHeader.*?\n\n/us";
+	private function extract_hyper($wikitext, $count) {
+		$hyperString = null;
+		$hyperPattern = "/$this->hyperHeader.*?\n\n/us";
 		$itemPattern = "/\[\[.*?\]\]/u";
-	
-	// If pattern returns results, then extract synonyms
-		if (preg_match_all($synPattern, $wikitext, $synMatch, PREG_PATTERN_ORDER) > 0) {
-		// There may be more than one synonym section. Fuse them together as string.
-			foreach ($synMatch[0] as $value) {
-				$synString .= $value;
+
+	// If pattern returns results, then extract hypernyms
+		if (preg_match_all($hyperPattern, $wikitext, $hyperMatch, PREG_PATTERN_ORDER) > 0) {
+		// There may be more than one hypernym section. Fuse them together as string.
+			foreach ($hyperMatch[0] as $value) {
+				$hyperString .= $value;
 			}
 		// Match all double-bracketed words ([[...]])
-			if (preg_match_all($itemPattern, $synString, $itemMatch, PREG_PATTERN_ORDER) > 0) {
+			if (preg_match_all($itemPattern, $hyperString, $itemMatch, PREG_PATTERN_ORDER) > 0) {
 				return array_slice($itemMatch[0], 0, $count);
 			}
 			else {
-				die("No synonyms could be identified.");
+				die("No hypernyms could be identified.");
 			}
-		}	
+		}
 		else {
-			die("No listed synonyms.");
+			die("No listed hypernyms.");
 		}
 	}
 /***********************************************************************************/
 // Removes unnecessary string elements from results
 /***********************************************************************************/
-	private function strip_tags($synArray) {
-		$strippedArray = $synArray;
+	private function strip_tags($hyperArray) {
+		$strippedArray = $hyperArray;
 	// Remove first half of entries such as [[...:word]]
 		$strippedArray = preg_replace("/\[\[.*?[|:]/u", "", $strippedArray);
 	// Remove brackets [[

--- a/lib/HyperParse.php
+++ b/lib/HyperParse.php
@@ -29,16 +29,16 @@ class HyperParse {
 /***********************************************************************************/
 // public methods
 /***********************************************************************************/
-	public function get_hyper($wikitext, $count) {
-		$hyperArray = $this->extract_hyper($wikitext, $count);
-		return $this->strip_tags($hyperArray);
+	public function getHyper($wikitext, $count) {
+		$hyperArray = $this->extractHyper($wikitext, $count);
+		return $this->stripTags($hyperArray);
 	}
 /***********************************************************************************/
 // private methods
 /***********************************************************************************/
 // Extracts hypernyms from wikitext
 /***********************************************************************************/
-	private function extract_hyper($wikitext, $count) {
+	private function extractHyper($wikitext, $count) {
 		$hyperString = null;
 		$hyperPattern = "/$this->hyperHeader.*?\n\n/us";
 		$itemPattern = "/\[\[.*?\]\]/u";
@@ -64,7 +64,7 @@ class HyperParse {
 /***********************************************************************************/
 // Removes unnecessary string elements from results
 /***********************************************************************************/
-	private function strip_tags($hyperArray) {
+	private function stripTags($hyperArray) {
 		$strippedArray = $hyperArray;
 	// Remove first half of entries such as [[...:word]]
 		$strippedArray = preg_replace("/\[\[.*?[|:]/u", "", $strippedArray);

--- a/lib/Lang/AbstractLang.php
+++ b/lib/Lang/AbstractLang.php
@@ -1,0 +1,27 @@
+<?php
+namespace ybourque\Wikparser\lib\Lang;
+
+use ArrayAccess;
+
+abstract class AbstractLang implements ArrayAccess
+{
+    public function offsetExists($key)
+    {
+        return property_exists($this, $key);
+    }
+
+    public function offsetGet($key)
+    {
+        return $this->$key;
+    }
+
+    public function offsetSet($key, $val)
+    {
+        $this->$key = $val;
+    }
+
+    public function offsetUnset($key)
+    {
+        $this->$key = null;
+    }
+}

--- a/lib/Lang/De.php
+++ b/lib/Lang/De.php
@@ -1,0 +1,18 @@
+<?php
+namespace ybourque\Wikparser\lib\Lang;
+
+class De extends AbstractLang
+{
+    protected $langCode = "de";
+    protected $langSeparator = "({{Sprache|";
+    protected $defHeader = "{{Bedeutungen}}";
+    protected $defTag = ":";
+    protected $synHeader = "{{Synonyme}}";
+    protected $hyperHeader = "{{Oberbegriffe}}";
+    protected $genderPattern = "(\{\{[mfn]\}\}\s===)";
+    protected $posMatchType = "preg";
+    protected $posPattern = "(\{\{Wortart\|\w+\|)";
+    protected $posArray = array();
+    protected $posExtraString = "{{Wortart|";
+    protected $langHeader = 'Deutsch}})\s*==';
+}

--- a/lib/Lang/En.php
+++ b/lib/Lang/En.php
@@ -1,0 +1,29 @@
+<?php
+namespace ybourque\Wikparser\lib\Lang;
+
+class En extends AbstractLang
+{
+    protected $langCode = "en";
+    protected $langSeparator = "----";
+    protected $defHeader = "";
+    protected $defTag = "# ";
+    protected $synHeader = "====Synonyms====";
+    protected $hyperHeader = "====Hypernyms====";
+    protected $genderPattern = "";
+    protected $posMatchType = "array";
+    protected $posPattern = "";
+    protected $posArray = array(
+        '===Noun===',
+        '===Verb===',
+        '===Adjective===',
+        '===Adverb===',
+        '===Preposition===',
+        '===Particle===',
+        '===Pronouns===',
+        '===Interjection===',
+        '===Conjunction===',
+        '===Article==='
+    );
+    protected $posExtraString = "=";
+    protected $langHeader = '==\s*English\s*==';
+}

--- a/lib/Lang/Es.php
+++ b/lib/Lang/Es.php
@@ -1,0 +1,18 @@
+<?php
+namespace ybourque\Wikparser\lib\Lang;
+
+class Es extends AbstractLang
+{
+    protected $langCode = "es";
+    protected $langSeparator = "";
+    protected $defHeader = "";
+    protected $defTag = ";";
+    protected $synHeader = "'''Sinónimo";
+    protected $hyperHeader = "";
+    protected $genderPattern = "(\s?(masculino|femenino)(\|es)?\}\}\s?===)";
+    protected $posMatchType = "preg";
+    protected $posPattern = "(===\s?\{\{\w*[\|\s])u";
+    protected $posArray = array();
+    protected $posExtraString = "";
+    protected $langHeader = '{{ES';
+}

--- a/lib/Lang/Fr.php
+++ b/lib/Lang/Fr.php
@@ -1,0 +1,18 @@
+<?php
+namespace ybourque\Wikparser\lib\Lang;
+
+class Fr extends AbstractLang
+{
+    protected $langCode = "fr";
+    protected $langSeparator = "== {{=";
+    protected $defHeader = "";
+    protected $defTag = "# ";
+    protected $synHeader = "==== {{S|synonymes}} ====";
+    protected $hyperHeader = "==== {{S|hyperonymes}} ====";
+    protected $genderPattern = "(\{\{([mf]|mf)\??\}\})";
+    protected $posMatchType = "preg";
+    protected $posPattern = "(\{\{\S\|[\d\w\s]+\|fr(\|num=[0-9])?\}\})u";
+    protected $posArray = array();
+    protected $posExtraString = "{{S|";
+    protected $langHeader = 'fr}}\s*==';
+}

--- a/lib/PosParse.php
+++ b/lib/PosParse.php
@@ -37,13 +37,13 @@ class PosParse {
 /***********************************************************************************/
 // public methods; used to retrieve contents of variables
 /***********************************************************************************/
-	public function get_pos($wikitext, $count) {
-		$posArray = $this->extract_pos($wikitext, $count);
+	public function getPos($wikitext, $count) {
+		$posArray = $this->extractPos($wikitext, $count);
 
 		include "./classes/class.strip.tags.php";
 		$stripTagsObject = new StripTags();
 
-		$posArray = $stripTagsObject->strip_tags($posArray, $this->langCode);
+		$posArray = $stripTagsObject->stripTags($posArray, $this->langCode);
 		return array_unique($posArray);
 	}
 /***********************************************************************************/
@@ -53,7 +53,7 @@ class PosParse {
 /***********************************************************************************/
 // Extracts every occurrence of a part of speech.
 /***********************************************************************************/
-	private function extract_pos($wikitext, $count) {
+	private function extractPos($wikitext, $count) {
 		$tempPosResults = array();
 
 	// If the matches are in an array

--- a/lib/PosParse.php
+++ b/lib/PosParse.php
@@ -39,10 +39,7 @@ class PosParse {
 /***********************************************************************************/
 	public function getPos($wikitext, $count) {
 		$posArray = $this->extractPos($wikitext, $count);
-
-		include "./classes/class.strip.tags.php";
 		$stripTagsObject = new StripTags();
-
 		$posArray = $stripTagsObject->stripTags($posArray, $this->langCode);
 		return array_unique($posArray);
 	}

--- a/lib/PosParse.php
+++ b/lib/PosParse.php
@@ -1,4 +1,6 @@
 <?php
+namespace ybourque\Wikparser\lib;
+
 /***********************************************************************************/
 // This class is used to parse the wikitionary raw data in order to extract parts
 // of speech for a given word.
@@ -10,17 +12,17 @@ class PosParse {
 // Variables
 /***********************************************************************************/
 	private $langCode;			// language code (e.g. en, fr, da, etc.)
-	private $posMatchType;		// POS Match Type, set in config file	
-	private $posArray;			// POS Array, set in config file	
-	private $posPattern;		// POS regex pattern, set in config file	
-	private $posExtraString;	// POS extra string, set in config file	
-	
+	private $posMatchType;		// POS Match Type, set in config file
+	private $posArray;			// POS Array, set in config file
+	private $posPattern;		// POS regex pattern, set in config file
+	private $posExtraString;	// POS extra string, set in config file
+
 /***********************************************************************************/
 // construct
 /***********************************************************************************/
 	public function __construct($langParameters) {
-		if 
-		(empty($langParameters['posMatchType']) || 
+		if
+		(empty($langParameters['posMatchType']) ||
 		(empty($langParameters['posPattern']) && empty($langParameters['posArray']))) {
 			die("ERROR: POS parameters are not set correctly for this language in language.config.php.");
 		}
@@ -37,10 +39,10 @@ class PosParse {
 /***********************************************************************************/
 	public function get_pos($wikitext, $count) {
 		$posArray = $this->extract_pos($wikitext, $count);
-		
+
 		include "./classes/class.strip.tags.php";
 		$stripTagsObject = new StripTags();
-		
+
 		$posArray = $stripTagsObject->strip_tags($posArray, $this->langCode);
 		return array_unique($posArray);
 	}
@@ -53,15 +55,15 @@ class PosParse {
 /***********************************************************************************/
 	private function extract_pos($wikitext, $count) {
 		$tempPosResults = array();
-		
+
 	// If the matches are in an array
 		if ($this->posMatchType == "array") {
 			foreach ($this->posArray as $value) {
 				if (strpos($wikitext, $value)) {
 					$tempPosResults[] = str_replace($this->posExtraString, "", $value);
 				}
-			}		
-		}		
+			}
+		}
 	// Else if the matches are part of a regular expression
 		else if ($this->posMatchType == "preg") {
 			preg_match_all($this->posPattern, $wikitext, $matches);
@@ -74,8 +76,8 @@ class PosParse {
 		else {
 			die("No POS type (preg or array) specified.");
 		}
-		
-	// Return results if array not empty.	
+
+	// Return results if array not empty.
 		if (empty($tempPosResults) !== true) {
 			return array_slice($tempPosResults, 0, $count);
 		}

--- a/lib/StripTags.php
+++ b/lib/StripTags.php
@@ -19,7 +19,7 @@ class StripTags {
 /***********************************************************************************/
 // public methods
 /***********************************************************************************/
-	public function strip_tags($array, $langCode) {
+	public function stripTags($array, $langCode) {
 		$tags_array = array("[", "]", "{", "}", "=");
 		foreach ($tags_array as $tag) {
 			$array = str_replace($tag, "", $array);

--- a/lib/StripTags.php
+++ b/lib/StripTags.php
@@ -1,4 +1,6 @@
 <?php
+namespace ybourque\Wikparser\lib;
+
 /***********************************************************************************/
 // This class strips common tags from Wiktionary's raw data.
 // Accepts an array.
@@ -8,7 +10,7 @@ class StripTags {
 /***********************************************************************************/
 // Variables
 /***********************************************************************************/
-	
+
 /***********************************************************************************/
 // construct
 /***********************************************************************************/
@@ -24,7 +26,7 @@ class StripTags {
 		}
 		foreach ($array as $string) {
 			$string = trim($string);
-		
+
 		// Trims language code from end of string if preceded by | (e.g. Spanish gender)
 			$finalArray[] = preg_replace("/\|$langCode$/", "", $string);
 		}

--- a/lib/SynParse.php
+++ b/lib/SynParse.php
@@ -1,69 +1,71 @@
 <?php
+namespace ybourque\Wikparser\lib;
+
 /***********************************************************************************/
-// This class is used to parse the wikitionary raw data in order to extract hypernyms
-// for a given word. Hypernyms are infrequent in Wiktionary entries.
+// This class is used to parse the wikitionary raw data in order to extract synonyms
+// for a given word. Synonyms are not systematically included in Wiktionary entries.
 // See the language.config.php file for setting language specific parameters.
 /***********************************************************************************/
 
-class HyperParse {
+class SynParse {
 /***********************************************************************************/
 // Variables
 /***********************************************************************************/
-	private $langCode;			// language code (e.g. en, fr, da, etc.)
-	private $hyperHeader;		// Hypernyms header, set in config file
-	
+	private $langCode;		// language code (e.g. en, fr, da, etc.)
+	private $synHeader; 	// Synonyms header, set in config file
+
 /***********************************************************************************/
 // construct
 /***********************************************************************************/
 	public function __construct($langParameters) {
-		if (empty($langParameters['hyperHeader'])) {
-			die("ERROR: Hypernym parameter is not set for this language in language.config.php.");
+		if (empty($langParameters['synHeader'])) {
+			die("ERROR: Synonym parameter is not set for this language in language.config.php.");
 		}
 		else {
 			$this->langCode = $langParameters['langCode'];
-			$this->hyperHeader = $langParameters['hyperHeader'];
+			$this->synHeader = $langParameters['synHeader'];
 		}
 	}
 /***********************************************************************************/
 // public methods
 /***********************************************************************************/
-	public function get_hyper($wikitext, $count) {
-		$hyperArray = $this->extract_hyper($wikitext, $count);
-		return $this->strip_tags($hyperArray);
+	public function get_syn($wikitext, $count) {
+		$synArray = $this->extract_syn($wikitext, $count);
+		return $this->strip_tags($synArray);
 	}
 /***********************************************************************************/
 // private methods
 /***********************************************************************************/
-// Extracts hypernyms from wikitext
+// Extracts synonyms from wikitext
 /***********************************************************************************/
-	private function extract_hyper($wikitext, $count) {
-		$hyperString = null;	
-		$hyperPattern = "/$this->hyperHeader.*?\n\n/us";
+	private function extract_syn($wikitext, $count) {
+		$synString = null;
+		$synPattern = "/$this->synHeader.*?\n\n/us";
 		$itemPattern = "/\[\[.*?\]\]/u";
-	
-	// If pattern returns results, then extract hypernyms
-		if (preg_match_all($hyperPattern, $wikitext, $hyperMatch, PREG_PATTERN_ORDER) > 0) {
-		// There may be more than one hypernym section. Fuse them together as string.
-			foreach ($hyperMatch[0] as $value) {
-				$hyperString .= $value;
+
+	// If pattern returns results, then extract synonyms
+		if (preg_match_all($synPattern, $wikitext, $synMatch, PREG_PATTERN_ORDER) > 0) {
+		// There may be more than one synonym section. Fuse them together as string.
+			foreach ($synMatch[0] as $value) {
+				$synString .= $value;
 			}
 		// Match all double-bracketed words ([[...]])
-			if (preg_match_all($itemPattern, $hyperString, $itemMatch, PREG_PATTERN_ORDER) > 0) {
+			if (preg_match_all($itemPattern, $synString, $itemMatch, PREG_PATTERN_ORDER) > 0) {
 				return array_slice($itemMatch[0], 0, $count);
 			}
 			else {
-				die("No hypernyms could be identified.");
+				die("No synonyms could be identified.");
 			}
-		}	
+		}
 		else {
-			die("No listed hypernyms.");
+			die("No listed synonyms.");
 		}
 	}
 /***********************************************************************************/
 // Removes unnecessary string elements from results
 /***********************************************************************************/
-	private function strip_tags($hyperArray) {
-		$strippedArray = $hyperArray;
+	private function strip_tags($synArray) {
+		$strippedArray = $synArray;
 	// Remove first half of entries such as [[...:word]]
 		$strippedArray = preg_replace("/\[\[.*?[|:]/u", "", $strippedArray);
 	// Remove brackets [[

--- a/lib/SynParse.php
+++ b/lib/SynParse.php
@@ -29,16 +29,16 @@ class SynParse {
 /***********************************************************************************/
 // public methods
 /***********************************************************************************/
-	public function get_syn($wikitext, $count) {
-		$synArray = $this->extract_syn($wikitext, $count);
-		return $this->strip_tags($synArray);
+	public function getSyn($wikitext, $count) {
+		$synArray = $this->extractSyn($wikitext, $count);
+		return $this->stripTags($synArray);
 	}
 /***********************************************************************************/
 // private methods
 /***********************************************************************************/
 // Extracts synonyms from wikitext
 /***********************************************************************************/
-	private function extract_syn($wikitext, $count) {
+	private function extractSyn($wikitext, $count) {
 		$synString = null;
 		$synPattern = "/$this->synHeader.*?\n\n/us";
 		$itemPattern = "/\[\[.*?\]\]/u";
@@ -64,7 +64,7 @@ class SynParse {
 /***********************************************************************************/
 // Removes unnecessary string elements from results
 /***********************************************************************************/
-	private function strip_tags($synArray) {
+	private function stripTags($synArray) {
 		$strippedArray = $synArray;
 	// Remove first half of entries such as [[...:word]]
 		$strippedArray = preg_replace("/\[\[.*?[|:]/u", "", $strippedArray);

--- a/lib/WikiExtract.php
+++ b/lib/WikiExtract.php
@@ -30,15 +30,15 @@ class WikiExtract {
 /***********************************************************************************/
 // public methods
 /***********************************************************************************/
-	public function get_wikitext($word) {
+	public function getWikiText($word) {
 		if ($this->wikiSource == 'local') {
-			$wikitext = $this->sql_fetch_data($word);
+			$wikitext = $this->sqlFetchData($word);
 		}
 		else if ($this->wikiSource == 'api') {
-			$wikitext = $this->get_wikitext_from_wiktionary($word);
+			$wikitext = $this->getWikiTextFromWiktionary($word);
 		}
 
-		return $this->lang_extract($wikitext);
+		return $this->langExtract($wikitext);
 	}
 /***********************************************************************************/
 // private methods
@@ -47,7 +47,7 @@ class WikiExtract {
 /***********************************************************************************/
 // Retrieves raw data via Wiktionary's API.
 /***********************************************************************************/
-	private function get_wikitext_from_wiktionary($word) {
+	private function getWikiTextFromWiktionary($word) {
 		$word = urlencode($word);
 
 	// Must be supplied, otherwise IP will be banned
@@ -73,7 +73,7 @@ class WikiExtract {
 /***********************************************************************************/
 // Retrieves raw data via a local MySQL copy of Wiktionary (defined in conc.php).
 /***********************************************************************************/
-	private function sql_fetch_data($word) {
+	private function sqlFetchData($word) {
 
 		include 'conc.php';
 		$word = mysqli_real_escape_string($conn, $word);
@@ -102,7 +102,7 @@ class WikiExtract {
 // Extracts content for specified language from raw wiktionary data. Some entries
 // contain text for other languages.
 /***********************************************************************************/
-	private function lang_extract($wikitext){
+	private function langExtract($wikitext){
 		$bln = false;
 
 		if ($this->langSeparator !== "") {

--- a/lib/WikiExtract.php
+++ b/lib/WikiExtract.php
@@ -1,5 +1,5 @@
 <?php
-namespace quuuit\Wikparser\lib;
+namespace ybourque\Wikparser\lib;
 /***********************************************************************************/
 // Gets all raw text for a given word via either Wiktionary's API or a local MySQL
 // copy (defined in conc.php). Accepts 3 variables:
@@ -16,7 +16,7 @@ class WikiExtract {
 	private $langCode; // 2-letter language code
 	private $langHeader; // language header from config file
 	private $langSeparator; // language separator string from config file
-	
+
 /***********************************************************************************/
 // construct
 /***********************************************************************************/
@@ -26,7 +26,7 @@ class WikiExtract {
 		$this->langHeader = $langParameters['langHeader'];
 		$this->langSeparator = $langParameters['langSeparator'];
 	}
-	
+
 /***********************************************************************************/
 // public methods
 /***********************************************************************************/
@@ -37,7 +37,7 @@ class WikiExtract {
 		else if ($this->wikiSource == 'api') {
 			$wikitext = $this->get_wikitext_from_wiktionary($word);
 		}
-		
+
 		return $this->lang_extract($wikitext);
 	}
 /***********************************************************************************/
@@ -49,17 +49,17 @@ class WikiExtract {
 /***********************************************************************************/
 	private function get_wikitext_from_wiktionary($word) {
 		$word = urlencode($word);
-	
+
 	// Must be supplied, otherwise IP will be banned
 		$userAgent = "Wikitionary Text Parser 0.3 (http://www.igrec.ca/projects)";
-	// Paramaters passed to the Wik API, including search word.	
+	// Paramaters passed to the Wik API, including search word.
 		$params = '?action=parse&prop=wikitext&page='.$word.'&format=xml';
-		
+
 		$ch = curl_init('https://'.$this->langCode.'.wiktionary.org/w/api.php'.$params);
 		curl_setopt($ch, CURLOPT_USERAGENT, $userAgent);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($ch,CURLOPT_ENCODING , "gzip");
-		
+
 		$wikiAPIResult = curl_exec($ch);
 		curl_close($ch);
 
@@ -69,25 +69,25 @@ class WikiExtract {
 		else {
 			return $wikiAPIResult;
 		}
-	}		
+	}
 /***********************************************************************************/
 // Retrieves raw data via a local MySQL copy of Wiktionary (defined in conc.php).
 /***********************************************************************************/
 	private function sql_fetch_data($word) {
-		
+
 		include 'conc.php';
 		$word = mysqli_real_escape_string($conn, $word);
-	
-	// 3 tables are used page->revision->text	
+
+	// 3 tables are used page->revision->text
 		$query = "SELECT t.old_text FROM text t ";
 		$query .= "JOIN revision r ON r.rev_text_id = t.old_id ";
 		$query .= "JOIN page p ON r.rev_page = p.page_id ";
 		$query .= "WHERE p.page_title = '$word' AND p.page_namespace = 0";
-		
+
 		if (!$queryResult = $conn->query($query)) {
 			die("Error: Couldn't query word.");
 		}
-		
+
 		if ($queryResult->num_rows > 0) {
 			while ($row = $queryResult->fetch_assoc()){
 				$wikitext = $row['old_text'];
@@ -96,7 +96,7 @@ class WikiExtract {
 		}
 		else {
 			die("No such word found.");
-		}				
+		}
 	}
 /***********************************************************************************/
 // Extracts content for specified language from raw wiktionary data. Some entries
@@ -104,10 +104,10 @@ class WikiExtract {
 /***********************************************************************************/
 	private function lang_extract($wikitext){
 		$bln = false;
-		
+
 		if ($this->langSeparator !== "") {
 			$languages = explode($this->langSeparator, $wikitext);
-		
+
 			foreach ($languages as $value) {
 				if (preg_match('/'.$this->langHeader.'/', $value) > 0) {
 					$wikitext = $value;

--- a/tests/test.php
+++ b/tests/test.php
@@ -1,0 +1,17 @@
+<?php
+use ybourque\Wikparser\Wikparser;
+
+require dirname(__DIR__) . "/vendor/autoload.php";
+
+$wik = new WikParser();
+$queries = ['def', 'pos', 'syn', 'hyper', 'gender'];
+$parsed = [];
+foreach ($queries as $query) {
+    $parsed[$query] = $wik->getWordDefiniton('simplement', $query, 'fr');
+}
+var_dump($parsed);
+
+/*
+requires a separate call for each element. modify to make one call and return
+all parsed elements?
+*/


### PR DESCRIPTION
This PR incorporates some initial consistency cleanups: namespace name, autoloading, and method naming style among them.

It also splits the $langParams values out to their own classes to reduce the volume of code in the top-level class.

Finally, lines with trailing whitespace have had that whitespace stripped. If that makes the diff too hard to read, you may wish to add ?w=1 to the end of the PR files URL, to hide the whitespace-only changes.

If you find this PR acceptable and merge it, I'll present a second PR with multiple-parse functionality.

Thanks!
