### PR TITLE
Enable multiple parses from one fetch

### DIFF
--- a/WikParser.php
+++ b/WikParser.php
@@ -26,7 +26,6 @@ class WikParser{
         $this->langParameters = $this->newLang($langCode);
 
         $wikitext = $this->getWikiText($this->langParameters, $this->source, $this->word);
-        var_dump($wikitext);
         $parsed = [];
         foreach ((array) $query as $q) {
             $parsed[$q] = $this->parseQuery($q, $wikitext);

--- a/WikParser.php
+++ b/WikParser.php
@@ -10,49 +10,28 @@ use ybourque\Wikparser\lib\WikiExtract;
 class WikParser{
     public $parsedDefinition='';
 
-    /** @var string */
-    protected $langHeader;
-
-    /**
-     * Set the language header.
-     * This is the header (usually a second-level header, i.e. H2 in HTML) under
-     * the words that are to be queried.
-     * For example, English is '==\w*English\w*=='.
-     * @param string $langHeader
-     */
-    public function setLangHeader($langHeader) {
-        $this->langHeader = $langHeader;
-    }
-
-    /**
-     * Get the language header regex used for $langCode language.
-     * For example, for 'en' (English) this is '==\s*English\s*=='.
-     * @param string $langCode The Wiktionary langage code (usually the same as ISO-639).
-     * @return string The regular expression used to determine the langage header.
-     */
-    public function getLangHeader($langCode = null) {
-        if ($this->langHeader) {
-            return $this->langHeader;
-        }
-        switch ($langCode) {
-            case 'fr':
-                return 'fr}}\s*==';
-            case 'es':
-                return '{{ES';
-            case 'de':
-                return 'Deutsch}})\s*==';
-            case 'en':
-            default:
-                return '==\s*English\s*==';
-        }
-    }
-
+    /***********************************************************************************/
+    /***********************************************************************************/
+    // Language code for search, default english (en)
+    /***********************************************************************************/
+    // Number of results; default '100'
+    /***********************************************************************************/
+    // Set wikisource to local if not set. Values either 'local' or 'api'.
+    /***********************************************************************************/
+    /***********************************************************************************/
     public function getWordDefiniton($word,$query='def',$langCode='en',$count=100,$source='api'){
         $this->word = $word;
         $this->count = $count;
         $this->source = $source;
         $this->langParameters = $this->newLang($langCode);
-        return $this->parseQuery($query);
+
+        $wikitext = $this->getWikiText($this->langParameters, $this->source, $this->word);
+        var_dump($wikitext);
+        $parsed = [];
+        foreach ((array) $query as $q) {
+            $parsed[$q] = $this->parseQuery($q, $wikitext);
+        }
+        return $parsed;
     }
 
     private function newLang($langCode)
@@ -61,93 +40,56 @@ class WikParser{
         return new $class();
     }
 
-    /***********************************************************************************/
-    /***********************************************************************************/
-// Language code for search, default english (en)
-    /***********************************************************************************/
-// Number of results; default '100'
-    /***********************************************************************************/
-// Set wikisource to local if not set. Values either 'local' or 'api'.
-    /***********************************************************************************/
-    /***********************************************************************************/
-    public function parseQuery($query){
+    private function parseQuery($query, $wikitext){
+        $parsedDefinition = [];
         switch ($query) {
             /***********************************************************************************/
             // Include defparse class and create new object with 3 variables.
             /***********************************************************************************/
             case "def":
-                if(isset($this->langParameters) and isset($this->word) and isset($this->source) and isset($this->count)){
-                    $DefParse = new DefParse($this->langParameters);
-                    $wikitext = $this->getWikiText($this->langParameters, $this->source, $this->word);
-                    if(isset($DefParse)){
-                        $parsedDefinition = $DefParse->getDef($wikitext, $this->count);
-                    }
-                }
+                $DefParse = new DefParse($this->langParameters);
+                $parsedDefinition = $DefParse->getDef($wikitext, $this->count);
                 break;
             /***********************************************************************************/
             // Include posparse class and create new object with 3 variables.
             /***********************************************************************************/
             case "pos":
-                if(isset($this->langParameters) and isset($this->word) and isset($this->source) and isset($this->count)){
-                    $posparse = new PosParse($this->langParameters);
-                    $wikitext = $this->getWikiText($this->langParameters, $this->source, $this->word);
-                    if(isset($DefParse)){
-                        $parsedDefinition = $posparse->getPos($wikitext, $this->count);
-                    }
-                }
+                $posparse = new PosParse($this->langParameters);
+                $parsedDefinition = $posparse->getPos($wikitext, $this->count);
                 break;
             /***********************************************************************************/
             // Include synparse class and create new object with 3 variables.
             /***********************************************************************************/
             case "syn":
-                if(isset($this->langParameters) and isset($this->word) and isset($this->source) and isset($this->count)){
-                    $SynParse = new SynParse($this->langParameters);
-                    $wikitext = $this->getWikiText($this->langParameters, $this->source, $this->word);
-                    if(isset($DefParse)){
-                        $parsedDefinition = $SynParse->getSyn($wikitext, $this->count);
-                    }
-                }
+                $SynParse = new SynParse($this->langParameters);
+                $parsedDefinition = $SynParse->getSyn($wikitext, $this->count);
                 break;
-
             /***********************************************************************************/
             // Include hyperparse class and create new object with 3 variables. (Hypernyms)
             /***********************************************************************************/
             case "hyper":
-                if(isset($this->langParameters) and isset($this->word) and isset($this->source) and isset($this->count)){
-                    $HyperParse = new HyperParse($this->langParameters);
-                    $wikitext = $this->getWikiText($this->langParameters, $this->source, $this->word);
-                    if(isset($DefParse)){
-                        $parsedDefinition = $HyperParse->getHyper($wikitext, $this->count);
-                    }
-                }
+                $HyperParse = new HyperParse($this->langParameters);
+                $parsedDefinition = $HyperParse->getHyper($wikitext, $this->count);
                 break;
             /***********************************************************************************/
             // Include genderparse class and create new object with 3 variables. (Gender)
             /***********************************************************************************/
             case "gender":
-                if(isset($this->langParameters) and isset($this->word) and isset($this->source) and isset($this->count)){
-                    $GenderParse = new GenderParse($this->langParameters);
-                    $wikitext = $this->getWikiText($this->langParameters, $this->source, $this->word);
-                    if(isset($DefParse)){
-                        $parsedDefinition = $GenderParse->getGender($wikitext, $this->count);
-                    }
-                }
+                $GenderParse = new GenderParse($this->langParameters);
+                $parsedDefinition = $GenderParse->getGender($wikitext, $this->count);
                 break;
             /***********************************************************************************/
             default:
                 echo "You must specify a valid query type ('pos', 'def', 'syn', 'hyper', or 'gender').";
                 break;
         }
-        if(isset($parsedDefinition)){
-            return $parsedDefinition;
-        }else{
-            return [];
-        }
+
+        return $parsedDefinition;
     }
 
     /***********************************************************************************/
-// Include wikiextract class and create new object with 2 variables. Returns the
-// contents of the wiktionary entry for a given word.
+    // Include wikiextract class and create new object with 2 variables. Returns the
+    // contents of the wiktionary entry for a given word.
     /***********************************************************************************/
     public function getWikiText($langParameters, $wikiSource, $word) {
         $WikiExtract = new WikiExtract($langParameters, $wikiSource);
@@ -155,7 +97,7 @@ class WikParser{
     }
 
     /***********************************************************************************/
-// Prints contents of array.
+    // Prints contents of array.
     /***********************************************************************************/
     public function printResults($array) {
         $resultseparator = " | ";
@@ -166,4 +108,3 @@ class WikParser{
         echo rtrim($printresults, $resultseparator);
     }
 }
-?>

--- a/lib/DefParse.php
+++ b/lib/DefParse.php
@@ -60,7 +60,7 @@ class DefParse {
 				return array_slice($defArray, 0, $count);
 			}
 			else {
-				die("No definitions section found.");
+				return array();
 			}
 		}
 		else {

--- a/lib/GenderParse.php
+++ b/lib/GenderParse.php
@@ -63,7 +63,7 @@ class GenderParse {
 			return array_unique($tempGenderResults);
 		}
 		else {
-			die("No gender found.");
+			return array();
 		}
 	}
 /***********************************************************************************/

--- a/lib/HyperParse.php
+++ b/lib/HyperParse.php
@@ -54,11 +54,11 @@ class HyperParse {
 				return array_slice($itemMatch[0], 0, $count);
 			}
 			else {
-				die("No hypernyms could be identified.");
+				return array();
 			}
 		}
 		else {
-			die("No listed hypernyms.");
+			return array();
 		}
 	}
 /***********************************************************************************/

--- a/lib/PosParse.php
+++ b/lib/PosParse.php
@@ -79,7 +79,7 @@ class PosParse {
 			return array_slice($tempPosResults, 0, $count);
 		}
 		else {
-			die("No POS found.");
+			return array();
 		}
 	}
 /***********************************************************************************/

--- a/lib/StripTags.php
+++ b/lib/StripTags.php
@@ -20,6 +20,7 @@ class StripTags {
 // public methods
 /***********************************************************************************/
 	public function stripTags($array, $langCode) {
+		$finalArray = array();
 		$tags_array = array("[", "]", "{", "}", "=");
 		foreach ($tags_array as $tag) {
 			$array = str_replace($tag, "", $array);

--- a/lib/SynParse.php
+++ b/lib/SynParse.php
@@ -54,11 +54,11 @@ class SynParse {
 				return array_slice($itemMatch[0], 0, $count);
 			}
 			else {
-				die("No synonyms could be identified.");
+				return array();
 			}
 		}
 		else {
-			die("No listed synonyms.");
+			return array();
 		}
 	}
 /***********************************************************************************/

--- a/tests/test.php
+++ b/tests/test.php
@@ -5,10 +5,7 @@ require dirname(__DIR__) . "/vendor/autoload.php";
 
 $wik = new WikParser();
 $queries = ['def', 'pos', 'syn', 'hyper', 'gender'];
-$parsed = [];
-foreach ($queries as $query) {
-    $parsed[$query] = $wik->getWordDefiniton('simplement', $query, 'fr');
-}
+$parsed = $wik->getWordDefiniton('simplement', $queries, 'fr');
 var_dump($parsed);
 
 /*


### PR DESCRIPTION
This PR adds the ability to return multiple parses from a single wikitext fetch. This cuts down on network traffic.  It additionally removes non-exceptional die() calls to return empty arrays, so as not to interrupt later parses.
