### PR TITLE
More robust DefParse

### DIFF
--- a/lib/DefParse.php
+++ b/lib/DefParse.php
@@ -1,5 +1,8 @@
 <?php
 namespace ybourque\Wikparser\lib;
+
+use ybourque\Wikparser\lib\Lang\AbstractLang;
+
 /***********************************************************************************/
 // This class is used to extract all definitions for a word.
 // See the language.config.php file for setting language specific parameters.
@@ -9,21 +12,18 @@ class DefParse {
 /***********************************************************************************/
 // Variables
 /***********************************************************************************/
-	private $sectionPattern; 	// definitions header, set in config file
-	private $defTag;		// definitions tag, set in config file
+	private $sectionPattern;
+	private $defTag; // definitions tag, set in config file
 
 /***********************************************************************************/
 // construct
 /***********************************************************************************/
-	public function __construct($langParameters) {
-		if (empty($langParameters['defHeader']) && empty($langParameters['defTag'])) {
-			die("ERROR: Definition parameters are not set for this language in language.config.php.");
-		}
+	public function __construct(AbstractLang $langParameters) {
 
 		// Find all matches for header + text until double newline.
 		if ($langParameters['defHeader']) {
 			// use an explicit definition header string
-			$this->sectionPattern = '/('.preg_quote($this->defHeader).'.*?\n\n)/su';
+			$this->sectionPattern = '/('.preg_quote($langParameters['defHeader']).'.*?\n\n)/su';
 		} elseif ($langParameters['posPattern']) {
 			// some languages, such as french, have definitions after the part-of-speech
 			$this->sectionPattern = "/(" . $langParameters['posPattern'] . '.*?\n\n)/su';

--- a/lib/DefParse.php
+++ b/lib/DefParse.php
@@ -9,8 +9,7 @@ class DefParse {
 /***********************************************************************************/
 // Variables
 /***********************************************************************************/
-	private $langCode;		// language code (e.g. en, fr, da, etc.)
-	private $defHeader; 	// definitions header, set in config file
+	private $sectionPattern; 	// definitions header, set in config file
 	private $defTag;		// definitions tag, set in config file
 
 /***********************************************************************************/
@@ -20,12 +19,20 @@ class DefParse {
 		if (empty($langParameters['defHeader']) && empty($langParameters['defTag'])) {
 			die("ERROR: Definition parameters are not set for this language in language.config.php.");
 		}
-		else {
-			$this->langCode = $langParameters['langCode'];
-			$this->defHeader = $langParameters['defHeader'];
-			$this->defTag = $langParameters['defTag'];
+
+		// Find all matches for header + text until double newline.
+		if ($langParameters['defHeader']) {
+			// use an explicit definition header string
+			$this->sectionPattern = '/('.preg_quote($this->defHeader).'.*?\n\n)/su';
+		} elseif ($langParameters['posPattern']) {
+			// some languages, such as french, have definitions after the part-of-speech
+			$this->sectionPattern = "/(" . $langParameters['posPattern'] . '.*?\n\n)/su';
 		}
+
+		$this->defTag = $langParameters['defTag'];
+		$this->tagPattern = "/\n".str_replace(" ", "\s", preg_quote($this->defTag)).".*/u";
 	}
+
 /***********************************************************************************/
 // public methods
 /***********************************************************************************/
@@ -40,37 +47,39 @@ class DefParse {
 // tags set in paramaters.
 /***********************************************************************************/
 	private function extractDef($wikitext, $count) {
-		$defArray = array();
-
-		if (!empty($this->defHeader)) {
-			$sectionPattern = "(".preg_quote($this->defHeader).".*?\n\n)s";
-		// Find all matches for header + text until double newline.
-			preg_match_all($sectionPattern, $wikitext, $sectionMatches);
-			if ($sectionMatches) {
-				$defPattern = "/\n".str_replace(" ", "\s", preg_quote($this->defTag)).".*/";
-				foreach ($sectionMatches[0] as $value) {
-				// Find all matches for deftag + text until newline.
-					preg_match_all($defPattern, $value, $defMatches);
-					if ($defMatches) {
-						foreach ($defMatches[0] as $value) {
-							$defArray[] = $value;
-						}
-					}
-				}
-				return array_slice($defArray, 0, $count);
-			}
-			else {
-				return array();
-			}
+		if ($this->sectionPattern) {
+			return $this->extractDefSection($wikitext, $count);
 		}
-		else {
-			$defPattern = "/\n".str_replace(" ", "\s", preg_quote($this->defTag)).".*/";
-			preg_match_all($defPattern, $wikitext, $matches);
-			if ($matches) {
-				return array_slice($matches[0], 0, $count);
-			}
+
+		// no section pattern, examine entire wikitext
+		preg_match_all($this->tagPattern, $wikitext, $matches);
+		if ($matches) {
+			return array_slice($matches[0], 0, $count);
+		} else {
+			return array();
 		}
 	}
+
+	private function extractDefSection($wikitext, $count)
+	{
+		preg_match_all($this->sectionPattern, $wikitext, $sectionMatches);
+		if (! $sectionMatches) {
+			return array();
+		}
+
+		$defArray = array();
+		foreach ($sectionMatches[0] as $value) {
+			// Find all matches for deftag + text until newline.
+			preg_match_all($this->tagPattern, $value, $tagMatches);
+			if ($tagMatches) {
+				foreach ($tagMatches[0] as $value) {
+					$defArray[] = $value;
+				}
+			}
+		}
+		return array_slice($defArray, 0, $count);
+	}
+
 /***********************************************************************************/
 // Strips tags used for additional info and links to other words.
 /***********************************************************************************/
@@ -89,5 +98,4 @@ class DefParse {
 		return $strippedArray;
 	}
 /***********************************************************************************/
-} // End of class.
-?>
+}

--- a/lib/Lang/AbstractLang.php
+++ b/lib/Lang/AbstractLang.php
@@ -5,6 +5,19 @@ use ArrayAccess;
 
 abstract class AbstractLang implements ArrayAccess
 {
+    protected $langCode;
+    protected $langSeparator;
+    protected $defHeader;
+    protected $defTag;
+    protected $synHeader;
+    protected $hyperHeader;
+    protected $genderPattern;
+    protected $posMatchType;
+    protected $posPattern;
+    protected $posArray = array();
+    protected $posExtraString;
+    protected $langHeader;
+
     public function offsetExists($key)
     {
         return property_exists($this, $key);

--- a/lib/Lang/Es.php
+++ b/lib/Lang/Es.php
@@ -11,7 +11,7 @@ class Es extends AbstractLang
     protected $hyperHeader = "";
     protected $genderPattern = "(\s?(masculino|femenino)(\|es)?\}\}\s?===)";
     protected $posMatchType = "preg";
-    protected $posPattern = "(===\s?\{\{\w*[\|\s])u";
+    protected $posPattern = "(===\s?\{\{\w*[\|\s])";
     protected $posArray = array();
     protected $posExtraString = "";
     protected $langHeader = '{{ES';

--- a/lib/Lang/Fr.php
+++ b/lib/Lang/Fr.php
@@ -11,7 +11,7 @@ class Fr extends AbstractLang
     protected $hyperHeader = "==== {{S|hyperonymes}} ====";
     protected $genderPattern = "(\{\{([mf]|mf)\??\}\})";
     protected $posMatchType = "preg";
-    protected $posPattern = "(\{\{\S\|[\d\w\s]+\|fr(\|num=[0-9])?\}\})u";
+    protected $posPattern = "(\{\{\S\|[\d\w\s]+\|fr(\|num=[0-9])?\}\})";
     protected $posArray = array();
     protected $posExtraString = "{{S|";
     protected $langHeader = 'fr}}\s*==';

--- a/lib/PosParse.php
+++ b/lib/PosParse.php
@@ -63,7 +63,7 @@ class PosParse {
 		}
 	// Else if the matches are part of a regular expression
 		else if ($this->posMatchType == "preg") {
-			preg_match_all($this->posPattern, $wikitext, $matches);
+			preg_match_all('/' . $this->posPattern . '/', $wikitext, $matches);
 			if (empty($matches[0]) !== true) {
 				foreach ($matches[0] as $value) {
 					$tempPosResults[] = str_replace($this->posExtraString, "", $value);

--- a/tests/test.php
+++ b/tests/test.php
@@ -5,7 +5,7 @@ require dirname(__DIR__) . "/vendor/autoload.php";
 
 $wik = new WikParser();
 $queries = ['def', 'pos', 'syn', 'hyper', 'gender'];
-$parsed = $wik->getWordDefiniton('simplement', $queries, 'fr');
+$parsed = $wik->getWordDefiniton('bon', $queries, 'fr');
 var_dump($parsed);
 
 /*


### PR DESCRIPTION
This PR makes DefParse more robust, in that it can now examine either an explicit defHeader section, or the part-of-speech section (as with French), for definitions.

It also includes some refactorings to reduce the size of individual methods, breaking them up into more "digestible" chunks.
